### PR TITLE
fix: remove inline styles and correct event duration

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,7 @@ import "./globals.css"
 
 export const metadata: Metadata = {
   title: "The Unstoppable Hackathon",
-  description: "48 hours of innovation, coding, and creativity, building decentralized unstoppable projects",
+  description: "33 hours of innovation, coding, and creativity, building decentralized unstoppable projects",
   keywords:
     "blockchains, cryptocurrencies, tokens, digital assets, decentralization, unstoppability, immutability, code is law, permissionlessness",
   generator: "v0.app",
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: "The Unstoppable Hackathon",
-    description: "48 hours of innovation, coding, and creativity, building decentralized unstoppable projects",
+    description: "33 hours of innovation, coding, and creativity, building decentralized unstoppable projects",
     url: "https://hackathon.stability.nexus",
     siteName: "The Unstoppable Hackathon",
     images: [
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "The Unstoppable Hackathon",
-    description: "48 hours of innovation, coding, and creativity, building decentralized unstoppable projects",
+    description: "33 hours of innovation, coding, and creativity, building decentralized unstoppable projects",
     images: [
       {
         url: "/images/unstoppable.svg",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -373,7 +373,7 @@ export default function HackathonPage() {
                 src="https://www.google.com/maps?q=The%20LNM%20Institute%20of%20Information%20Technology,%20Via%20Jamdoli,%20Jaipur&amp;output=embed"
                 width="100%"
                 height="100%"
-                style={{ border: 0 }}
+                className="border-0"
                 allowFullScreen
                 loading="lazy"
                 referrerPolicy="no-referrer-when-downgrade"


### PR DESCRIPTION
## Summary
This PR improves code quality by removing inline styles and correcting metadata.

## Changes
- Replaced inline `style` attribute with Tailwind `className` in iframe component
- Fixed event duration from 48 hours to 33 hours in all metadata (meta tags, OpenGraph, Twitter card)

## Why These Changes?
1. **Inline styles** prevent CSS caching and optimization, moving to Tailwind improves performance
2. **Duration mismatch** was causing incorrect information in SEO and social media shares

## Testing
- ✅ Verified no compilation errors
- ✅ Checked iframe still renders correctly
- ✅ Metadata now accurately reflects 33-hour event duration

This contribution is part of the Unstoppable Hackathon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hackathon event duration from 48 hours to 33 hours in page metadata, including OpenGraph and Twitter card descriptions.

* **Style**
  * Improved Google Maps iframe styling implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->