### PR TITLE
docs: add GPLv3 license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,43 @@
+# GNU General Public License v3.0
+
+Copyright (C) 2025 The Stable Order
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+## Full License Text
+
+The full text of the GNU General Public License v3.0 can be found at:
+https://www.gnu.org/licenses/gpl-3.0.en.html
+
+## Summary
+
+This license grants users the freedom to:
+- Use the software for any purpose
+- Study and modify the source code
+- Share the software with others
+- Share modified versions with others
+
+Under the following terms:
+- Modified versions must also be licensed under GPLv3
+- Source code must be made available
+- Changes must be documented
+- No warranty is provided
+
+## Contact
+
+For questions about this license or the project:
+- Website: https://hackathon.stability.nexus
+- Organization: The Stable Order


### PR DESCRIPTION
## Summary
Adds GPLv3 license file to establish clear legal terms for the project.

## Changes
- Added `LICENSE.md` with GNU General Public License v3.0
- Included license summary and user freedoms
- Added copyright notice for The Stable Order

## Why This Change?
- Provides legal clarity for contributors and users
- GPLv3 is the recommended license for frontend projects in The Stable Order ecosystem


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GNU General Public License v3.0 to the project, defining usage rights, obligations, and warranty terms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->